### PR TITLE
Add pulse animations using onPressIn and onPressOut events

### DIFF
--- a/App/Components/TalkCard.js
+++ b/App/Components/TalkCard.js
@@ -74,16 +74,20 @@ const getImage = (speakers) => (
 const StyledContainer = Animatable.createAnimatableComponent(Container)
 
 class TalkCard extends React.Component {
-  onPress = () => {
-    const { onPress } = this.props
-    this.refs.container.pulse(300).then((endState) => onPress && onPress())
+  onPressIn = () => {
+    this.container.transition({ scale: 1.0 }, { scale: 1.03 }, 300)
   }
+
+  onPressOut = () => {
+    this.container.transitionTo({ scale: 1.0 }, 300)
+  }
+
   render () {
-    const { session, begin, end } = this.props
+    const { session, begin, end, onPress } = this.props
     const { speakers, title } = session
     return (
-      <TouchableWithoutFeedback onPress={this.onPress}>
-        <StyledContainer ref='container'>
+      <TouchableWithoutFeedback onPress={onPress} onPressIn={this.onPressIn} onPressOut={this.onPressOut}>
+        <StyledContainer ref={ref => { this.container = ref }}>
           <Row>
             <TalkInfo>
               <Speaker>{ makeSpeakersText(speakers) }</Speaker>

--- a/App/Components/TalkCard.js
+++ b/App/Components/TalkCard.js
@@ -75,7 +75,7 @@ const StyledContainer = Animatable.createAnimatableComponent(Container)
 
 class TalkCard extends React.Component {
   onPressIn = () => {
-    this.container.transition({ scale: 1.0 }, { scale: 1.03 }, 300)
+    this.container.transition({ scale: 1.0 }, { scale: 0.95 }, 300)
   }
 
   onPressOut = () => {

--- a/App/Components/WorkshopTile/WorkshopTile.js
+++ b/App/Components/WorkshopTile/WorkshopTile.js
@@ -52,15 +52,19 @@ const getImage = (speakers) => (
 
 const StyledRow = Animatable.createAnimatableComponent(Row)
 class WorkshopTile extends React.Component {
-  onPress = () => {
-    const { onPress } = this.props
-    this.refs.view.pulse(300).then((endState) => onPress && onPress())
+  onPressIn = () => {
+    this.container.transition({ scale: 1.0 }, { scale: 1.03 }, 300)
   }
+
+  onPressOut = () => {
+    this.container.transitionTo({ scale: 1.0 }, 300)
+  }
+
   render () {
-    const {item} = this.props
+    const { item, onPress } = this.props
     return (
-      <TouchableWithoutFeedback onPress={this.onPress}>
-        <StyledRow ref='view'>
+      <TouchableWithoutFeedback onPress={onPress} onPressIn={this.onPressIn} onPressOut={this.onPressOut}>
+        <StyledRow ref={ref => { this.container = ref }}>
           <Headline numberOfLines={2}>{item && item.title}</Headline>
           <Desc numberOfLines={3}>{item && item.description}</Desc>
           <ImageContainer>

--- a/App/Components/WorkshopTile/WorkshopTile.js
+++ b/App/Components/WorkshopTile/WorkshopTile.js
@@ -53,7 +53,7 @@ const getImage = (speakers) => (
 const StyledRow = Animatable.createAnimatableComponent(Row)
 class WorkshopTile extends React.Component {
   onPressIn = () => {
-    this.container.transition({ scale: 1.0 }, { scale: 1.03 }, 300)
+    this.container.transition({ scale: 1.0 }, { scale: 0.95 }, 300)
   }
 
   onPressOut = () => {


### PR DESCRIPTION
Animate the cards when user starts touching them instead when the touch occurred. This should give better feedback for the user that the cards are touchable.

Also, use callback pattern for refs as the string refs are legacy: https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs