### PR TITLE
WIP: Show all items for schedule (lightning talks, breaks etc.)

### DIFF
--- a/App/Components/TalkCard.js
+++ b/App/Components/TalkCard.js
@@ -24,15 +24,7 @@ class TalkCard extends React.Component {
     const { onPress, onPressIn, onPressOut } = this.props
     const { session, begin, end } = this.props
     const { speakers = [], title = '' } = session
-    if (title.toLowerCase().indexOf('breakfast') > -1) {
-      return <View />
-    }
-    if (title.toLowerCase().indexOf('lunch') > -1) {
-      return <View />
-    }
-    if (title.toLowerCase().indexOf('coffee break') > -1) {
-      return <View />
-    }
+
     const image = getImage(speakers)
     return (
       <TouchableWithoutFeedback onPress={() => onPress()} onPressIn={() => onPressIn(this.container)} onPressOut={() => onPressOut(this.container)}>

--- a/App/Components/TalkCard.js
+++ b/App/Components/TalkCard.js
@@ -2,11 +2,13 @@ import React from 'react'
 import { TouchableWithoutFeedback, View } from 'react-native'
 import Icon from 'react-native-vector-icons/FontAwesome'
 import * as Animatable from 'react-native-animatable'
+import styled from 'styled-components/native'
+import R from 'ramda'
 
 import {Container, AlignRight, Speaker, Row, Title, TalkInfo, ImageContainer, TimeInfo, RoundedImage, Time} from './CardCommon'
 
 import { Metrics, Colors } from '../Themes'
-import {scaleOnPress} from './ScaleOnPress'
+import { scaleOnPress } from './ScaleOnPress'
 
 const makeSpeakersText = (speakers) =>
   speakers && speakers.length > 0 ? speakers.map(a => a.name).join('\n') : ''
@@ -20,16 +22,33 @@ const getImage = (speakers) => (
 const StyledContainer = Animatable.createAnimatableComponent(Container)
 
 class TalkCard extends React.Component {
+  get icon() {
+    const { session } = this.props
+    const { type } = session
+
+    const iconForType = R.cond([
+      [R.equals('lightningTalk'), R.always('star-o')],
+      [R.equals('keynote'),       R.always('lightbulb-o')],
+      [R.T,                       R.always(null)]
+    ])
+
+    const icon = iconForType(type)
+    return icon
+      ? <Icon style={{ marginRight: 5 }} name={icon} color={Colors.background} size={Metrics.icons.small} />
+      : null
+  }
+
   render () {
     const { onPress, onPressIn, onPressOut } = this.props
     const { session, begin, end } = this.props
-    const { speakers = [], title = '' } = session
+    const { speakers = [], title = '', type } = session
 
     const image = getImage(speakers)
     return (
       <TouchableWithoutFeedback onPress={() => onPress()} onPressIn={() => onPressIn(this.container)} onPressOut={() => onPressOut(this.container)}>
         <StyledContainer ref={ref => { this.container = ref }}>
           <Row>
+            {this.icon}
             <TalkInfo>
               <Title>{ title || 'To be announced' }</Title>
             </TalkInfo>

--- a/App/Components/TalkCard.js
+++ b/App/Components/TalkCard.js
@@ -48,7 +48,6 @@ class TalkCard extends React.Component {
       <TouchableWithoutFeedback onPress={() => onPress()} onPressIn={() => onPressIn(this.container)} onPressOut={() => onPressOut(this.container)}>
         <StyledContainer ref={ref => { this.container = ref }}>
           <Row>
-            {this.icon}
             <TalkInfo>
               <Title>{ title || 'To be announced' }</Title>
             </TalkInfo>

--- a/App/Components/TalkListing.js
+++ b/App/Components/TalkListing.js
@@ -27,32 +27,6 @@ export default class TalkListing extends React.Component {
     />
   }
 
-  renderSectionHeader = ({ section }) => {
-    if (!section.title) {
-      return null
-    }
-
-    const { width } = Dimensions.get('window')
-    return (
-      <SectionHeader width={width}>
-        <SectionHeaderText>{section.title}</SectionHeaderText>
-      </SectionHeader>
-    )
-  }
-
-  renderSectionFooter = ({ section }) => {
-    if (!section.title) {
-      return null
-    }
-
-    const { width } = Dimensions.get('window')
-    return (
-      <SectionHeader width={width}>
-        <SectionHeaderText>{`End of ${section.title}`}</SectionHeaderText>
-      </SectionHeader>
-    )
-  }
-
   render () {
     const dataWithSections = this.props.data.map((interval, index) => {
       const title = interval.sessions.length > 1
@@ -77,8 +51,6 @@ export default class TalkListing extends React.Component {
         sections={dataWithSections}
         renderItem={this.renderSingleSession}
         keyExtractor={(item, index) => `list-${index}`}
-        renderSectionHeader={this.renderSectionHeader}
-        renderSectionFooter={this.renderSectionFooter}
       />
     )
   }

--- a/App/Components/TalkListing.js
+++ b/App/Components/TalkListing.js
@@ -1,37 +1,84 @@
 import React from 'react'
+import { SectionList, Dimensions } from 'react-native'
 import styled from 'styled-components/native'
 
 import TalkCard from './TalkCard'
-import { Colors } from '../Themes'
+import { Colors, Fonts, Metrics } from '../Themes'
 
-const FlatList = styled.FlatList`
-  background-color: ${Colors.reactFinlandBlue};
+const SectionHeaderText = styled.Text`
+  color: ${Colors.snow};
+  font-size: ${Fonts.size.regular};
+  font-family: ${Fonts.type.base};
+`
+
+const SectionHeader = styled.View`
+  padding: 10px;
+  width: ${props => props.width}
+  backgroundColor: ${Colors.reactFinlandBlue}
 `
 
 export default class TalkListing extends React.Component {
-  constructor (props) {
-    super(props)
-
-    this.renderInterval = this.renderInterval.bind(this)
-  }
-
-  renderInterval ({item: { begin, end, sessions }}) {
-    const session = sessions[0]
+  renderSingleSession = ({ item: session }) => {
     return <TalkCard
       onPress={() => { this.props.onSessionSelected(session) }}
       session={session}
-      begin={begin}
-      end={end}
+      begin={session.begin}
+      end={session.end}
     />
   }
 
-  render () {
-    const hasSessions = ({ sessions }) => sessions && sessions.length > 0
+  renderSectionHeader = ({ section }) => {
+    if (!section.title) {
+      return null
+    }
+
+    const { width } = Dimensions.get('window')
     return (
-      <FlatList
-        keyExtractor={(item, index) => `${index}`}
-        data={this.props.data.filter(hasSessions)}
-        renderItem={this.renderInterval}
+      <SectionHeader width={width}>
+        <SectionHeaderText>{section.title}</SectionHeaderText>
+      </SectionHeader>
+    )
+  }
+
+  renderSectionFooter = ({ section }) => {
+    if (!section.title) {
+      return null
+    }
+
+    const { width } = Dimensions.get('window')
+    return (
+      <SectionHeader width={width}>
+        <SectionHeaderText>{`End of ${section.title}`}</SectionHeaderText>
+      </SectionHeader>
+    )
+  }
+
+  render () {
+    const dataWithSections = this.props.data.map((interval, index) => {
+      const title = interval.sessions.length > 1
+        ? interval.sessions[0].title
+        : null
+      const sessions = interval.sessions.length > 1
+        ? interval.sessions.slice(1)
+        : interval.sessions
+
+      return {
+        data: sessions.map(session => ({
+          ...session,
+          begin: interval.begin,
+          end: interval.end
+        })),
+        title
+      }
+    })
+
+    return (
+      <SectionList
+        sections={dataWithSections}
+        renderItem={this.renderSingleSession}
+        keyExtractor={(item, index) => `list-${index}`}
+        renderSectionHeader={this.renderSectionHeader}
+        renderSectionFooter={this.renderSectionFooter}
       />
     )
   }

--- a/App/Components/TalkListing.story.js
+++ b/App/Components/TalkListing.story.js
@@ -6,225 +6,295 @@ import TalkListing from './TalkListing'
 
 const intervals = [
   {
-    'begin': '08:00',
-    'end': '09:00',
-    'sessions': [
+    "begin": "08:00",
+    "end": "09:00",
+    "sessions": [
       {
-        'title': 'Registration, Finnish breakfast.',
-        'description': "Trust me, it's the best.",
-        'speakers': null
+        "title": "Registration, Finnish breakfast.",
+        "description": "Trust me, it's the best.",
+        "type": null,
+        "keywords": null,
+        "speakers": null
       }
     ]
   },
   {
-    'begin': '09:00',
-    'end': '10:00',
-    'sessions': [
+    "begin": "09:00",
+    "end": "09:45",
+    "sessions": [
       {
-        'title': '',
-        'description': '',
-        'speakers': [
+        "title": "How React changed everything",
+        "description": "\nThis talk will examine how React changed the front end landscape as we know it. We'll start by recounting the pre-React landscape, including prior art. Next, we'll venture into the introduction of React, and its reception and growth.\n\nBut most importantly, we will take a look at the core idea of React, and why it transcends language or rendering target and posit on what that means going forward, including what React might look like years from now.\n  ",
+        "type": "keynote",
+        "keywords": [
+          "React"
+        ],
+        "speakers": [
           {
-            'name': 'Ken Wheeler',
-            'about': 'Ken is the Director of Open Source at Formidable, the author of several popular open source libraries, and a frequent conference speaker often focusing on alternative uses of React.\n\nHe is the creator of libraries such as Spectacle, react-music, react-game-kit and Webpack Dashboard. He also maintains a healthy Twitter presence, and enjoys red meat, whiskey and recreational archery.',
-            'image': 'ken.jpg'
+            "name": "Ken Wheeler",
+            "about": "Ken is the Director of Open Source at Formidable, the author of several popular open source libraries, and a frequent conference speaker often focusing on alternative uses of React.\n\nHe is the creator of libraries such as Spectacle, react-music, react-game-kit and Webpack Dashboard. He also maintains a healthy Twitter presence, and enjoys red meat, whiskey and recreational archery.",
+            "image": "speakers/ken.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '10:00',
-    'end': '11:00',
-    'sessions': [
+    "begin": "10:00",
+    "end": "10:45",
+    "sessions": [
       {
-        'title': 'Declarative state and side effects',
-        'description': 'Writing declarative code for our UIs is so common that we do not even think about it. But when it comes to writing logic for managing state and side effects it requires a lot of discipline to get the same benefits. We are going to talk about how we can get help writing our business logic in a declarative manner and see what benefits it gives us.',
-        'speakers': [
+        "title": "Declarative state and side effects",
+        "description": "Writing declarative code for our UIs is so common that we do not even think about it. But when it comes to writing logic for managing state and side effects it requires a lot of discipline to get the same benefits. We are going to talk about how we can get help writing our business logic in a declarative manner and see what benefits it gives us.",
+        "type": "presentation",
+        "keywords": [
+          "Cerebral",
+          "React",
+          "State management"
+        ],
+        "speakers": [
           {
-            'name': 'Christian Alfoni',
-            'about': 'Christian has been crunching JavaScript for about 8 years. In the recent years open source and writing articles has become a passion. Throwing bad and not so bad ideas out there to see what is valuable to people. Author of Cerebral, created Webpackbin and JSBlog... amongst other things.',
-            'image': 'christian.jpg'
+            "name": "Christian Alfoni",
+            "about": "Christian has been crunching JavaScript for about 8 years. In the recent years open source and writing articles has become a passion. Throwing bad and not so bad ideas out there to see what is valuable to people. Author of Cerebral, created Webpackbin and JSBlog... amongst other things.",
+            "image": "speakers/christian.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '11:00',
-    'end': '11:30',
-    'sessions': [
+    "begin": "11:00",
+    "end": "11:30",
+    "sessions": [
       {
-        'title': 'Lightning talks',
-        'description': null,
-        'speakers': null
+        "title": "Lightning talks",
+        "description": null,
+        "type": null,
+        "keywords": null,
+        "speakers": null
       },
       {
-        'title': 'Immer: Immutability made easy',
-        'description': "Immer is a tiny package that allows you to work with immutable data structures with unprecedented ease. It doesn't require learning new data structures or update APIs, but instead creates a temporarily shadow tree which can be modified using the standard JavaScript APIs. The shadow tree will be used to generate your next immutable state tree. Join this talk to see how to write your reducers in a much more readable way, with half the code and without requiring additional large libraries.",
-        'speakers': [
+        "title": "Immer: Immutability made easy",
+        "description": "Immer is a tiny package that allows you to work with immutable data structures with unprecedented ease. It doesn't require learning new data structures or update APIs, but instead creates a temporarily shadow tree which can be modified using the standard JavaScript APIs. The shadow tree will be used to generate your next immutable state tree. Join this talk to see how to write your reducers in a much more readable way, with half the code and without requiring additional large libraries.",
+        "type": "lightningTalk",
+        "keywords": [
+          "Immer"
+        ],
+        "speakers": [
           {
-            'name': 'Michel Weststrate',
-            'about': 'Full-stack tech lead and open source evangelist at Mendix. Author of MobX, MobX-State-Tree and Immer. On a quest to make programming as natural as possible.',
-            'image': 'michel.jpg'
+            "name": "Michel Weststrate",
+            "about": "Full-stack tech lead and open source evangelist at Mendix. Author of MobX, MobX-State-Tree and Immer. On a quest to make programming as natural as possible.",
+            "image": "speakers/michel.jpg"
           }
         ]
       },
       {
-        'title': 'Breaking Down Your Web App',
-        'description': '\nLet’s face it – the question is not *if* your codebase will become a horrible, unmaintainable mess, it’s only a question of *when*…\n\nWhat architecture patterns and strategies are there to break down your web application’s code into cleanly separated components? How can you compose your software of “Lego bricks” that you can simply replace with shiny new ones when they have become rotten?\n\nPatrick will show you how to be proud of writing code that’s easy to throw away instead of being proud of writing code that haunts your colleagues and your future self forever!\n\nHe will show some hands-on examples from his current work on the relaunch of eBay’s automotive online community MOTOR-TALK.de. While these are based on JavaScript, React and Redux, the underlying patterns will be useful for users of other languages and frameworks.\n  ',
-        'speakers': [
+        "title": "Breaking Down Your Web App",
+        "description": "\nLet’s face it – the question is not *if* your codebase will become a horrible, unmaintainable mess, it’s only a question of *when*…\n\nWhat architecture patterns and strategies are there to break down your web application’s code into cleanly separated components? How can you compose your software of “Lego bricks” that you can simply replace with shiny new ones when they have become rotten?\n\nPatrick will show you how to be proud of writing code that’s easy to throw away instead of being proud of writing code that haunts your colleagues and your future self forever!\n\nHe will show some hands-on examples from his current work on the relaunch of eBay’s automotive online community MOTOR-TALK.de. While these are based on JavaScript, React and Redux, the underlying patterns will be useful for users of other languages and frameworks.\n  ",
+        "type": "lightningTalk",
+        "keywords": [
+          "Legacy",
+          "React",
+          "Redux"
+        ],
+        "speakers": [
           {
-            'name': 'Patrick Hund',
-            'about': "Patrick helps React and Node.js conquer the tech stack at eBay in Berlin. He has been a professional software developer since 2000 and joined eBay in 2010. Notable projects are the relaunch of the homepage of eBay's car trading platform mobile.de in 2015 and the rewrite of eBay’s automotive online community MOTOR-TALK.de (ongoing, since 2017).",
-            'image': 'patrick-hund.jpg'
+            "name": "Patrick Hund",
+            "about": "Patrick helps React and Node.js conquer the tech stack at eBay in Berlin. He has been a professional software developer since 2000 and joined eBay in 2010. Notable projects are the relaunch of the homepage of eBay's car trading platform mobile.de in 2015 and the rewrite of eBay’s automotive online community MOTOR-TALK.de (ongoing, since 2017).",
+            "image": "speakers/patrick-hund.jpg"
           }
         ]
       },
       {
-        'title': 'How to use React, webpack and other buzzwords if there is no need',
-        'description': 'The best way to study a new development approach is to do it in practice. But good projects built with modern technologies most often require developers with experience in these technologies. One of the options to get this is a side project. What can it be in React?\n\nVarya will show how to generate a multilingual static website using Metalsmith, React and other modern technologies and tools. For over a year, she has been using this stack to build her personal blog and it turned out to be expressive, fast and convenient. After all, it’s our beloved React.',
-        'speakers': [
+        "title": "How to use React, webpack and other buzzwords if there is no need",
+        "description": "The best way to study a new development approach is to do it in practice. But good projects built with modern technologies most often require developers with experience in these technologies. One of the options to get this is a side project. What can it be in React?\n\nVarya will show how to generate a multilingual static website using Metalsmith, React and other modern technologies and tools. For over a year, she has been using this stack to build her personal blog and it turned out to be expressive, fast and convenient. After all, it’s our beloved React.",
+        "type": "lightningTalk",
+        "keywords": [
+          "React",
+          "Tooling"
+        ],
+        "speakers": [
           {
-            'name': 'Varya Stepanova',
-            'about': 'Varya Stepanova is a developer enthusiast for modular web and pattern libraries. She loves automation, also in the development processes, strongly believes in open-source community and likes social media. Originally from Russia, she now lives in Helsinki with her family and two cats.',
-            'image': 'varya.jpg'
+            "name": "Varya Stepanova",
+            "about": "Varya Stepanova is a developer enthusiast for modular web and pattern libraries. She loves automation, also in the development processes, strongly believes in open-source community and likes social media. Originally from Russia, she now lives in Helsinki with her family and two cats.",
+            "image": "speakers/varya.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '11:30',
-    'end': '12:30',
-    'sessions': [
+    "begin": "11:30",
+    "end": "12:30",
+    "sessions": [
       {
-        'title': 'Lunch',
-        'description': "It's functional. You are **not** supposed to like it.",
-        'speakers': null
+        "title": "Lunch",
+        "description": "It's functional. You are **not** supposed to like it.",
+        "type": null,
+        "keywords": null,
+        "speakers": null
       }
     ]
   },
   {
-    'begin': '12:30',
-    'end': '13:00',
-    'sessions': [
+    "begin": "12:30",
+    "end": "13:15",
+    "sessions": [
       {
-        'title': 'Panel',
-        'description': 'Panel discussion.',
-        'speakers': null
-      }
-    ]
-  },
-  {
-    'begin': '13:00',
-    'end': '14:00',
-    'sessions': [
-      {
-        'title': 'Styled Components, SSR, and Theming',
-        'description': 'All you need to know to become hero of CSS-in-JS with `styled-components`. We will go through the new API, performance improvements, server side rendering with Next.js and the theming manager available with v2 of `styled-components`.',
-        'speakers': [
+        "title": "Styled Components, SSR, and Theming",
+        "description": "All you need to know to become hero of CSS-in-JS with `styled-components`. We will go through the new API, performance improvements, server side rendering with Next.js and the theming manager available with v2 of `styled-components`.",
+        "type": "presentation",
+        "keywords": [
+          "React",
+          "Server Side Rendering",
+          "Styling"
+        ],
+        "speakers": [
           {
-            'name': 'Kasia Jastrzębska',
-            'about': 'Frontend developer with over 6 years of experience around various frameworks and libs knowledge in my basket (such as React+Redux, Polymer, Ember, Backbone). Always eager to go deeper ;D',
-            'image': 'kasia.jpg'
+            "name": "Kasia Jastrzębska",
+            "about": "Frontend developer with over 6 years of experience around various frameworks and libs knowledge in my basket (such as React+Redux, Polymer, Ember, Backbone). Always eager to go deeper ;D",
+            "image": "speakers/kasia.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '14:00',
-    'end': '15:00',
-    'sessions': [
+    "begin": "13:30",
+    "end": "14:15",
+    "sessions": [
       {
-        'title': 'Universal React Apps Using Next.js',
-        'description': 'Every user’s hardware is different, and processing speed can hinder user experience on client-side rendered React applications. Server-side rendering and code-splitting can drastically improve user experience by minimizing the work that the client has to do.\n\nIt’s easy to get lost in the lingo, so come learn what it all means and how to easily build universal React apps using the Next.js framework. We’ll walk through the concepts and use code examples to cement your understanding. You’ll get the most out of this session if you’re comfortable with React and ES6 syntax.',
-        'speakers': [
+        "title": "Universal React Apps Using Next.js",
+        "description": "Every user’s hardware is different, and processing speed can hinder user experience on client-side rendered React applications. Server-side rendering and code-splitting can drastically improve user experience by minimizing the work that the client has to do.\n\nIt’s easy to get lost in the lingo, so come learn what it all means and how to easily build universal React apps using the Next.js framework. We’ll walk through the concepts and use code examples to cement your understanding. You’ll get the most out of this session if you’re comfortable with React and ES6 syntax.",
+        "type": "presentation",
+        "keywords": [
+          "Next.js",
+          "React",
+          "Server Side Rendering",
+          "Universal React"
+        ],
+        "speakers": [
           {
-            'name': 'Sia Karamalegos',
-            'about': 'Sia Karamalegos is the founder and lead developer for Clio + Calliope Web Development. She has over 15 years of experience in technology, strategy, project management, and operations from small startups to large corporations across multiple industries, especially high-tech and education. She leverages her depth of experience with software engineering to build high-value applications.',
-            'image': 'sia.jpg'
+            "name": "Sia Karamalegos",
+            "about": "Sia Karamalegos is the founder and lead developer for Clio + Calliope Web Development. She has over 15 years of experience in technology, strategy, project management, and operations from small startups to large corporations across multiple industries, especially high-tech and education. She leverages her depth of experience with software engineering to build high-value applications.",
+            "image": "speakers/sia.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '15:00',
-    'end': '15:45',
-    'sessions': [
+    "begin": "14:15",
+    "end": "14:45",
+    "sessions": [
       {
-        'title': 'React Testing',
-        'description': '',
-        'speakers': [
+        "title": "Coffee break",
+        "description": "We don't mind if you drink tea, though. Water is available as well.",
+        "type": null,
+        "keywords": null,
+        "speakers": null
+      }
+    ]
+  },
+  {
+    "begin": "14:45",
+    "end": "15:30",
+    "sessions": [
+      {
+        "title": "React Testing",
+        "description": "Build apps is hard, super hard but not testing them makes them even harder as time goes by. Ever changed a component and then broke something on the other side of the app? Testing is important! Let's see how we can achieve inner peace in our apps by testing, we will go over Enzyme, Snapshot testing, UI testing and introduce many ways to make tests easier and more enjoyable.",
+        "type": "presentation",
+        "keywords": [
+          "React",
+          "Testing"
+        ],
+        "speakers": [
           {
-            'name': 'Sara Vieira',
-            'about': 'Front-End Developer at @YLDio, open sorcerer, maker of useless modules, Blogger, Drummer and horror movie fan girl.',
-            'image': 'sara.jpg'
+            "name": "Sara Vieira",
+            "about": "Front-End Developer at @YLDio, open sorcerer, maker of useless modules, Blogger, Drummer and horror movie fan girl.",
+            "image": "speakers/sara.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '15:45',
-    'end': '16:30',
-    'sessions': [
+    "begin": "15:45",
+    "end": "16:30",
+    "sessions": [
       {
-        'title': 'Detox: A year in. Building it, Testing with it',
-        'description': '\nA year in, developing and using Detox in production taught us a lot. From designing its API to consuming it, testing real user scenarios to advanced mocking, we learned what makes sense when E2E testing an app and what doesn’t.\n\nIn this talk, we’ll discuss how Detox works and what makes it deterministic, cover some advanced use cases and methodologies, go over new features and tease the ones that are upcoming.\n',
-        'speakers': [
+        "title": "Detox: A year in. Building it, Testing with it",
+        "description": "\nA year in, developing and using Detox in production taught us a lot. From designing its API to consuming it, testing real user scenarios to advanced mocking, we learned what makes sense when E2E testing an app and what doesn’t.\n\nIn this talk, we’ll discuss how Detox works and what makes it deterministic, cover some advanced use cases and methodologies, go over new features and tease the ones that are upcoming.\n",
+        "type": "presentation",
+        "keywords": [
+          "Detox",
+          "React",
+          "React Native",
+          "Testing",
+          "Tooling"
+        ],
+        "speakers": [
           {
-            'name': 'Rotem Mizrachi-Meidan',
-            'about': 'Rotem is a Software Engineer, open source advocate, passionate about Android, React Native, mobile performance, writing developer tools and Lego! In his current position at Wix, Rotem is working with React Native, writing infrastructure and testing tools.',
-            'image': 'rotem.jpg'
+            "name": "Rotem Mizrachi-Meidan",
+            "about": "Rotem is a Software Engineer, open source advocate, passionate about Android, React Native, mobile performance, writing developer tools and Lego! In his current position at Wix, Rotem is working with React Native, writing infrastructure and testing tools.",
+            "image": "speakers/rotem.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '16:30',
-    'end': '17:00',
-    'sessions': [
+    "begin": "16:30",
+    "end": "17:00",
+    "sessions": [
       {
-        'title': 'Coffee break',
-        'description': "We don't mind if you drink tea, though. Water is available as well.",
-        'speakers': null
+        "title": "Coffee break",
+        "description": "We don't mind if you drink tea, though. Water is available as well.",
+        "type": null,
+        "keywords": null,
+        "speakers": null
       }
     ]
   },
   {
-    'begin': '17:00',
-    'end': '17:30',
-    'sessions': [
+    "begin": "17:00",
+    "end": "17:30",
+    "sessions": [
       {
-        'title': 'Lightning talks',
-        'description': null,
-        'speakers': null
+        "title": "Lightning talks",
+        "description": null,
+        "type": null,
+        "keywords": null,
+        "speakers": null
       },
       {
-        'title': 'To be announced',
-        'description': 'To be announced',
-        'speakers': [
+        "title": "To be announced",
+        "description": "To be announced",
+        "type": "lightningTalk",
+        "keywords": [
+          "Babel",
+          "Tooling"
+        ],
+        "speakers": [
           {
-            'name': 'Sven Sauleau',
-            'about': 'Sven is a software engineer living in France and mostly working with Golang and JavaScript. OSS enthusiast and one of the persons behind Babel.',
-            'image': 'sven.jpg'
+            "name": "Sven Sauleau",
+            "about": "Sven is a software engineer living in France and mostly working with Golang and JavaScript. OSS enthusiast and one of the persons behind Babel.",
+            "image": "speakers/sven.jpg"
           }
         ]
       }
     ]
   },
   {
-    'begin': '17:30',
-    'end': '18:00',
-    'sessions': [
+    "begin": "17:30",
+    "end": "18:00",
+    "sessions": [
       {
-        'title': 'Panel',
-        'description': 'Panel discussion to end the day.',
-        'speakers': null
+        "title": "Panel",
+        "description": "Panel discussion to end the day.",
+        "type": null,
+        "keywords": null,
+        "speakers": null
       }
     ]
   }

--- a/App/Containers/TalkScreen.js
+++ b/App/Containers/TalkScreen.js
@@ -12,7 +12,7 @@ const Screen = styled.View`
   flex: 1;
 `
 
-class TalkScreenOld extends Component {
+class TalkScreen extends Component {
   render () {
     let { data, navigation, selectSession } = this.props
     const {state: {routeName}} = navigation
@@ -42,4 +42,4 @@ const mapStateToProps = ({schedule}) => ({
   data: schedule.data
 })
 
-export default connect(mapStateToProps, mapDispatchToProps)(TalkScreenOld)
+export default connect(mapStateToProps, mapDispatchToProps)(TalkScreen)

--- a/App/Sagas/SchedulesSagas.js
+++ b/App/Sagas/SchedulesSagas.js
@@ -5,7 +5,7 @@ import ScheduleActions from '../Redux/ScheduleRedux'
 
 const getSchedules = {
   query: gql`
-  { 
+  {
     schedules {
     day,
        intervals {
@@ -14,6 +14,7 @@ const getSchedules = {
          sessions {
            title
            description
+           type
            speakers {
              name
              about


### PR DESCRIPTION
This is still work in progress.

- Display all items in the listing, including lightning talks & breaks
- Converted the FlatList into SectionList and added section header for lightning talks.
  - Does not look very good, I will probably just convert it back to FlatList and differentiate the different sessions using different kinds of cards
- Added an icon for lightning talks and keynotes.
- Should we style the cards differently for different session? Breaks etc. need a type if we want to do that